### PR TITLE
Add configurable logging options to HTTPLogger

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,6 @@ RSpec/ExampleLength:
 
 RSpec/MessageSpies:
   EnforcedStyle: receive
+
+RSpec/MultipleExpectations:
+  Max: 3

--- a/lib/http_logger/config.rb
+++ b/lib/http_logger/config.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module HTTPLogger
+  # Config class for HTTPLogger
+  # This class holds configuration options for logging HTTP requests and responses.
+  #
+  # @example
+  #   HTTPLogger.configure do |config|
+  #     config.log_request = false
+  #     config.log_response = false
+  #     config.log_connection = false
+  #   end
+  #  # @see HTTPLogger.configure
+  #
+  # @attr_accessor [Boolean] log_request Whether to log HTTP requests.
+  # @attr_accessor [Boolean] log_response Whether to log HTTP responses.
+  # @attr_accessor [Boolean] log_connection Whether to log connection details.
+  class Config
+    attr_accessor :log_request, :log_response, :log_connection
+
+    def initialize
+      @log_request = true
+      @log_response = true
+      @log_connection = true
+    end
+  end
+end

--- a/lib/http_logger/http_logger.rb
+++ b/lib/http_logger/http_logger.rb
@@ -1,11 +1,21 @@
 # frozen_string_literal: true
 
+require_relative 'config'
+
 # HTTPLogger is a simple HTTP request/response logger for Ruby applications.
 module HTTPLogger
   class << self
+    def config
+      @config ||= Config.new
+    end
+
+    def configure
+      yield(config)
+    end
+
     def log(params = {})
-      log_request(params[:method], params[:url], params[:request])
-      log_response(params[:response])
+      log_request(params[:method], params[:url], params[:request]) if config.log_request
+      log_response(params[:response]) if config.log_response
     end
 
     private

--- a/lib/http_logger/patches/net/http.rb
+++ b/lib/http_logger/patches/net/http.rb
@@ -14,7 +14,7 @@ module Net
       original_connect
 
       # Hook after connect
-      puts "[HTTPLogger] Connected to #{address}:#{port}"
+      puts "[HTTPLogger] Connected to #{address}:#{port}" if HTTPLogger.config.log_connection
     end
 
     def request(req, body = nil, &)

--- a/spec/http_logger/http_logger_spec.rb
+++ b/spec/http_logger/http_logger_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe HTTPLogger do
+  describe '.config' do
+    it 'returns a config object' do
+      expect(described_class.config).to be_a(HTTPLogger::Config)
+    end
+
+    it 'has default config values' do
+      config = described_class.config
+      expect(config.log_request).to be(true)
+      expect(config.log_response).to be(true)
+      expect(config.log_connection).to be(true)
+    end
+  end
+
+  describe '.configure' do
+    after do
+      # Reset config to defaults after each test
+      described_class.configure do |config|
+        config.log_request = true
+        config.log_response = true
+        config.log_connection = true
+      end
+    end
+
+    it 'yields the config object' do
+      expect { |b| described_class.configure(&b) }.to yield_with_args(described_class.config)
+    end
+
+    it 'allows changing config options' do
+      described_class.configure do |config|
+        config.log_request = false
+        config.log_response = false
+        config.log_connection = false
+      end
+
+      config = described_class.config
+
+      expect(config.log_request).to be(false)
+      expect(config.log_response).to be(false)
+      expect(config.log_connection).to be(false)
+    end
+  end
+
+  describe '.log' do
+    let(:request) { { headers: { 'Content-Type' => 'application/json' }, body: '{"foo":"bar"}' } }
+    let(:response) { { code: 200, headers: { 'Content-Length' => '123' }, body: '{"baz":"qux"}' } }
+    let(:params) { { method: 'GET', url: 'http://example.com', request: request, response: response } }
+
+    it 'logs request and response when enabled' do
+      output = capture_stdout { described_class.log(params) }
+      expect(output).to include('[HTTPLogger] Request: GET http://example.com')
+      expect(output).to include('[HTTPLogger] Response: 200')
+    end
+
+    def capture_stdout
+      original_stdout = $stdout
+      $stdout = StringIO.new
+      yield
+      $stdout.string
+    ensure
+      $stdout = original_stdout
+    end
+
+    it 'does not log request when log_request is false' do
+      described_class.config.log_request = false
+      expect { described_class.log(params) }.not_to output(/Request:/).to_stdout
+      described_class.config.log_request = true
+    end
+
+    it 'does not log response when log_response is false' do
+      described_class.config.log_response = false
+      expect { described_class.log(params) }.not_to output(/Response:/).to_stdout
+      described_class.config.log_response = true
+    end
+  end
+end


### PR DESCRIPTION
Introduces a Config class and configuration methods to HTTPLogger, allowing selective logging of requests, responses, and connections. Updates Net::HTTP patch to respect the new log_connection setting. Also updates RuboCop config to limit multiple expectations in RSpec tests.

Closes #2 